### PR TITLE
Fix library route error handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -54,7 +54,6 @@ app.get("/library", function(req, res) {
       res.json(dbLibrary);
     })
     .catch(function(err) {
-      t;
       res.json(err);
     });
 });


### PR DESCRIPTION
## Summary
- remove stray `t;` statement in `/library` route

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68415a3ed120832fb618c49c6914e54b