### PR TITLE
Extend library system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+MONGODB_URI=mongodb://localhost/populate

--- a/models/Checkout.js
+++ b/models/Checkout.js
@@ -1,0 +1,12 @@
+var mongoose = require("mongoose");
+var Schema = mongoose.Schema;
+
+var checkoutSchema = new Schema({
+  user: { type: Schema.Types.ObjectId, ref: "User", required: true },
+  book: { type: Schema.Types.ObjectId, ref: "Book", required: true },
+  dueDate: Date,
+  returned: { type: Boolean, default: false }
+});
+
+var Checkout = mongoose.model("Checkout", checkoutSchema);
+module.exports = Checkout;

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,21 @@
+var mongoose = require("mongoose");
+var bcrypt = require("bcryptjs");
+var Schema = mongoose.Schema;
+
+var userSchema = new Schema({
+  username: { type: String, required: true, unique: true, trim: true },
+  password: { type: String, required: true }
+});
+
+userSchema.pre("save", function(next) {
+  if (!this.isModified("password")) return next();
+  this.password = bcrypt.hashSync(this.password, 10);
+  next();
+});
+
+userSchema.methods.comparePassword = function(pass, cb) {
+  bcrypt.compare(pass, this.password, cb);
+};
+
+var User = mongoose.model("User", userSchema);
+module.exports = User;

--- a/models/index.js
+++ b/models/index.js
@@ -1,4 +1,6 @@
 module.exports = {
   Book: require("./Book"),
-  Library: require("./Library")
+  Library: require("./Library"),
+  User: require("./User"),
+  Checkout: require("./Checkout")
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
   },
   "repository": {
     "type": "git",
@@ -18,7 +19,10 @@
   },
   "homepage": "https://github.com/fred1525/Mongoose-Populate-Practice-18#readme",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "dotenv": "^16.3.1",
     "express": "^4.17.1",
+    "express-session": "^1.17.0",
     "mongoose": "^5.7.12"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -7,14 +7,29 @@
   </head>
   <body>
     <h1>Enter a book into the library</h1>
-    <form action="/submit" method="post">
+    <form action="/books" method="post">
       <input type="text" name="author" placeholder="Author" />
       <input type="text" name="title" placeholder="Title" />
       <input type="submit" />
-      <br />
-      <a href="/books">See your books!</a>
-      <a href="/library">See your library!</a>
-      <a href="/populated">See your library, populated with books!</a>
     </form>
+
+    <h2>Account</h2>
+    <form action="/register" method="post">
+      <input type="text" name="username" placeholder="Username" />
+      <input type="password" name="password" placeholder="Password" />
+      <button type="submit">Register</button>
+    </form>
+
+    <form action="/login" method="post">
+      <input type="text" name="username" placeholder="Username" />
+      <input type="password" name="password" placeholder="Password" />
+      <button type="submit">Login</button>
+    </form>
+
+    <br />
+    <a href="/books">See your books!</a>
+    <a href="/library">See your library!</a>
+    <a href="/populated">See your library, populated with books!</a>
+    <a href="/checkout">See checkouts</a>
   </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -1,32 +1,83 @@
 var express = require("express");
 var mongoose = require("mongoose");
+var session = require("express-session");
+require("dotenv").config();
+
 var db = require("./models");
 
-var PORT = 3000;
+var PORT = process.env.PORT || 3000;
 
 var app = express();
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use(
+  session({
+    secret: "librarysecret",
+    resave: false,
+    saveUninitialized: false
+  })
+);
 
 app.use(express.static("public"));
 
-mongoose.connect("mongodb://localhost/populate", { useNewUrlParser: true });
+mongoose.connect(process.env.MONGODB_URI || "mongodb://localhost/populate", {
+  useNewUrlParser: true,
+  useUnifiedTopology: true
+});
 
-db.Library.create({ name: "Campus Library" })
-  .then(function(dbLibrary) {
-    console.log(dbLibrary);
-  })
-  .catch(function(err) {
-    console.log(err);
+// seed a library if none exist
+db.Library.findOne({}).then(function(found) {
+  if (!found) {
+    db.Library.create({ name: "Campus Library" }).catch(function(err) {
+      console.log(err);
+    });
+  }
+});
+
+function isAuth(req, res, next) {
+  if (req.session.userId) return next();
+  res.status(401).json({ message: "unauthorized" });
+}
+
+// Authentication routes
+app.post("/register", function(req, res) {
+  db.User.create(req.body)
+    .then(function() {
+      res.json({ message: "registered" });
+    })
+    .catch(function(err) {
+      res.status(400).json(err);
+    });
+});
+
+app.post("/login", function(req, res) {
+  db.User.findOne({ username: req.body.username }).then(function(user) {
+    if (!user) return res.status(400).json({ message: "invalid" });
+    user.comparePassword(req.body.password, function(err, match) {
+      if (match) {
+        req.session.userId = user._id;
+        res.json({ message: "logged in" });
+      } else {
+        res.status(400).json({ message: "invalid" });
+      }
+    });
   });
+});
 
-app.post("/submit", function(req, res) {
+app.post("/logout", function(req, res) {
+  req.session.destroy(function() {
+    res.json({ message: "logged out" });
+  });
+});
+
+// Book routes
+app.post("/books", isAuth, function(req, res) {
   db.Book.create(req.body)
-    .then(function(dbbook) {
+    .then(function(dbBook) {
       return db.Library.findOneAndUpdate(
         {},
-        { $push: { books: dbbook._id } },
+        { $push: { books: dbBook._id } },
         { new: true }
       );
     })
@@ -48,6 +99,27 @@ app.get("/books", function(req, res) {
     });
 });
 
+app.put("/books/:id", isAuth, function(req, res) {
+  db.Book.findByIdAndUpdate(req.params.id, req.body, { new: true })
+    .then(function(book) {
+      res.json(book);
+    })
+    .catch(function(err) {
+      res.json(err);
+    });
+});
+
+app.delete("/books/:id", isAuth, function(req, res) {
+  db.Book.findByIdAndDelete(req.params.id)
+    .then(function() {
+      res.json({ message: "deleted" });
+    })
+    .catch(function(err) {
+      res.json(err);
+    });
+});
+
+// Library routes
 app.get("/library", function(req, res) {
   db.Library.find({})
     .then(function(dbLibrary) {
@@ -58,11 +130,83 @@ app.get("/library", function(req, res) {
     });
 });
 
+app.post("/library", isAuth, function(req, res) {
+  db.Library.create(req.body)
+    .then(function(lib) {
+      res.json(lib);
+    })
+    .catch(function(err) {
+      res.json(err);
+    });
+});
+
+app.put("/library/:id", isAuth, function(req, res) {
+  db.Library.findByIdAndUpdate(req.params.id, req.body, { new: true })
+    .then(function(lib) {
+      res.json(lib);
+    })
+    .catch(function(err) {
+      res.json(err);
+    });
+});
+
+app.delete("/library/:id", isAuth, function(req, res) {
+  db.Library.findByIdAndDelete(req.params.id)
+    .then(function() {
+      res.json({ message: "deleted" });
+    })
+    .catch(function(err) {
+      res.json(err);
+    });
+});
+
+// Populated library
 app.get("/populated", function(req, res) {
   db.Library.find({})
     .populate("books")
     .then(function(dbLibrary) {
       res.json(dbLibrary);
+    })
+    .catch(function(err) {
+      res.json(err);
+    });
+});
+
+// Checkout routes
+app.post("/checkout", isAuth, function(req, res) {
+  var due = req.body.dueDate || new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  db.Checkout.create({
+    user: req.session.userId,
+    book: req.body.bookId,
+    dueDate: due
+  })
+    .then(function(checkout) {
+      res.json(checkout);
+    })
+    .catch(function(err) {
+      res.json(err);
+    });
+});
+
+app.post("/return/:id", isAuth, function(req, res) {
+  db.Checkout.findByIdAndUpdate(
+    req.params.id,
+    { returned: true },
+    { new: true }
+  )
+    .then(function(checkout) {
+      res.json(checkout);
+    })
+    .catch(function(err) {
+      res.json(err);
+    });
+});
+
+app.get("/checkout", isAuth, function(req, res) {
+  db.Checkout.find({ user: req.session.userId })
+    .populate("book")
+    .then(function(list) {
+      res.json(list);
     })
     .catch(function(err) {
       res.json(err);


### PR DESCRIPTION
## Summary
- add auth/session and book checkout features
- create user and checkout models
- support CRUD operations for books and libraries
- expose environment variables via dotenv and `.env.example`
- extend the simple frontend with login and register forms

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68415ba5e4f0832fa4e60ee9aced883f